### PR TITLE
change default port to 4000 to prevent conflicts with Rails apps

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -7,7 +7,7 @@ module.exports = {
   serviceName: 'GMT3k',
 
   // Default port that prototype runs on
-  port: '3000',
+  port: '4000',
 
   // Enable or disable password protection on production
   useAuth: 'true',


### PR DESCRIPTION
The default port for the server to run on was 3000, which is also
the default port for Rails apps. This commit changes the default port
to 4000 to prevent conflicts with any Rails apps that might be
running on your local machine.