### PR TITLE
remove test/ prefix from urls

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -19,14 +19,14 @@ router.get('/', function (req, res) {
 // add your routes here
 
 // nominals
-router.get('/test/nominal/rand/', function(req, res) {
+router.get('/nominal/rand/', function(req, res) {
   var n = Math.floor(Math.random() * nominals.length);
-  res.redirect('/test/nominal/' + n);
+  res.redirect('/nominal/' + n);
 });
 
-router.get('/test/nominal/:index', function(req, res) {
+router.get('/nominal/:index', function(req, res) {
   var nominal = nominals[req.params.index];
-  res.render('test/nominal', {
+  res.render('nominal', {
     next: getNext(req.params.index, nominals.length),
     prev: getPrev(req.params.index, nominals.length),
     nominal: nominal,
@@ -34,28 +34,28 @@ router.get('/test/nominal/:index', function(req, res) {
   });
 });
 
-router.get('/test/nominal/', function(req, res) {
-  res.redirect('/test/nominal/0');
+router.get('/nominal/', function(req, res) {
+  res.redirect('/nominal/0');
 });
 
 
 // gangs
-router.get('/test/gang/rand/', function(req, res) {
+router.get('/gang/rand/', function(req, res) {
   var n = Math.floor(Math.random() * gangs.length);
-  res.redirect('/test/gang/' + n);
+  res.redirect('/gang/' + n);
 });
 
-router.get('/test/gang/:index', function(req, res) {
+router.get('/gang/:index', function(req, res) {
   var gang = gangs[req.params.index];
-  res.render('test/gang', {
+  res.render('gang', {
     next: getNext(req.params.index, gangs.length),
     prev: getPrev(req.params.index, gangs.length),
     gang: gang
   });
 });
 
-router.get('/test/gang/', function(req, res) {
-  res.redirect('/test/gang/0');
+router.get('/gang/', function(req, res) {
+  res.redirect('/gang/0');
 });
 
 

--- a/app/views/gang.html
+++ b/app/views/gang.html
@@ -17,9 +17,9 @@
 
       <br><br><br><br>
       <ul class="nav-links">
-        <li><a href="/test/gang/{{prev}}">Previous</a></li>
-        <li><a href="/test/gang/rand/">Random</a></li>
-        <li><a href="/test/gang/{{next}}">Next</a></li>
+        <li><a href="/gang/{{prev}}">Previous</a></li>
+        <li><a href="/gang/rand/">Random</a></li>
+        <li><a href="/gang/{{next}}">Next</a></li>
       </ul>
 
     </div>

--- a/app/views/nominal.html
+++ b/app/views/nominal.html
@@ -74,7 +74,7 @@
           {% if affiliations.length %}
             <ul class="list list-bullet">
               {% for affiliation in affiliations %}
-              <li><a href="/test/gang/{{affiliation.index}}">{{affiliation.name}}</a></li>
+              <li><a href="/gang/{{affiliation.index}}">{{affiliation.name}}</a></li>
               {% endfor %}
             </ul>
           {% else %}
@@ -94,9 +94,9 @@
 
       <br><br><br><br>
       <ul class="nav-links">
-        <li><a href="/test/nominal/{{prev}}">Previous</a></li>
-        <li><a href="/test/nominal/rand/">Random</a></li>
-        <li><a href="/test/nominal/{{next}}">Next</a></li>
+        <li><a href="/nominal/{{prev}}">Previous</a></li>
+        <li><a href="/nominal/rand/">Random</a></li>
+        <li><a href="/nominal/{{next}}">Next</a></li>
       </ul>
 
     </div>


### PR DESCRIPTION
The 'test/' prefix in URLs and routes is no longer needed and
can be removed. This commit removes it.

The new URLs are:

/test/nominal -> /nominal
/test/gang -> /gang

etc