### PR TITLE
Nominal search results buff

### DIFF
--- a/app/assets/sass/local/images.scss
+++ b/app/assets/sass/local/images.scss
@@ -21,4 +21,10 @@
 .avatar-thumb {
   width: 10vw;
   height: 10vw;
+  @include media(mobile) {
+    width: calc(100% - 30px);
+    height: 85vw; 
+    border-radius: 3vw;
+    margin-bottom: 1em;   
+  }
 }

--- a/app/assets/sass/local/search-results.scss
+++ b/app/assets/sass/local/search-results.scss
@@ -1,10 +1,16 @@
 .heading-inner{
   float:left;
+  @include media(mobile) {
+    float:none;
+  }
 }
 .system-ids{
   float:right;
   font-size:0.8em;
   color:#888;
+  @include media(mobile) {
+    float:none;
+  }
 }
 .search-result {
   margin-bottom: 35px;
@@ -26,6 +32,10 @@
 .search-result-detail {
   float: left;
   width:82%;
+  @include media(mobile) {
+    padding: 0 15px;
+    width: calc(100% - 30px);
+  }
   h3 {
     margin: 0;
   }

--- a/app/assets/sass/local/search-results.scss
+++ b/app/assets/sass/local/search-results.scss
@@ -1,5 +1,13 @@
+.heading-inner{
+  float:left;
+}
+.system-ids{
+  float:right;
+  font-size:0.8em;
+  color:#888;
+}
 .search-result {
-  margin-bottom: 20px;
+  margin-bottom: 35px;
   margin-top: 20px;
   overflow: hidden;
 }
@@ -7,7 +15,7 @@
 .search-result-avatar-wrapper {
   display: inline-block;
   float: left;
-  margin-right: 10px;
+  margin-right: 25px;
 
   @include media(mobile) {
     text-align: center;
@@ -17,7 +25,7 @@
 
 .search-result-detail {
   float: left;
-
+  width:82%;
   h3 {
     margin: 0;
   }

--- a/app/views/includes/search_result.html
+++ b/app/views/includes/search_result.html
@@ -5,60 +5,58 @@
 
 
 <div class="search-result-detail">
-  <h3 class="heading-medium">
-    <a href="/nominal/{{result.index}}">{{result.given_names}} {{result.family_name}}</a>
-  </h3>
-  <dl class="aliases">
-    <dt>Known aliases:</dt>
+  <div class="heading-container">
+    <div class = "heading-inner">
+      <h3 class="heading-medium">
+        <a href="/nominal/{{result.index}}">{{result.given_names}} {{result.family_name}}</a>
+      </h3>
+    </div>
+    <div class="system-ids">
+      <span>NOMIS ID:</span>
+      <span>{{result.nomis_id}}</span>
+      <span>PNC ID:</span>
+      <span>{{result.pnc_id}}</span>
+    </div>
+  </div>
+  <dl>
+    <dt>Gender:</dt>
     <dd>
-      {% if result.aliases.length %}
-        {{ result.aliases.join(', ') }}
+      {% if result.gender === 'M' %}
+      Male
       {% else %}
-      none
+      Female
       {% endif %}
     </dd>
-  </dl>
-  <dl>
     <dt>Date of birth:</dt>
     <dd>{{result.dob.displayDob}}</dd>
-
-    <dt>Gender:</dt>
-    <dd>{{result.gender}}</dd>
   </dl>
+  {% if result.aliases.length %}
+    <dl class="aliases">
+      <dt>Known aliases:</dt>
+      <dd>
+          {{ result.aliases.join(', ') }}
+      </dd>
+    </dl>
+  {% endif %}
 
-  <dl class="system-ids">
-    <dt>Offender ID:</dt>
-    <dd>{{result.offender_id}}</dd>
-
-    <dt>NOMIS ID:</dt>
-    <dd>{{result.nomis_id}}</dd>
-
-    <dt>PNC ID:</dt>
-    <dd>{{result.pnc_id}}</dd>
-  </dl>
-  <dl class="marks">
-    <dt>Identifying marks:</dt>
-    <dd>
-      {% if result.identifying_marks.length %}
-        {{ result.identifying_marks.join(', ') }}
-      {% else %}
-        none
-      {% endif %}
-    </dd>
-  </dl>
-  <dl class="affiliations">
-    <dt>Known affiliations:</dt>
-    <dd>
-      {% if affiliations.length %}
-        <ul class="list list-bullet">
-          {% for affiliation in affiliations %}
-          <li><a href="/ocg/{{affiliation.index}}">{{affiliation.name}}</a></li>
-          {% endfor %}
-        </ul>
-      {% else %}
-      none
-      {% endif %}
-    </dd>
-
-  </dl>
+  {% if result.identifying_marks.length %}
+    <dl class="marks">
+      <dt>Identifying marks:</dt>
+      <dd>     
+          {{ result.identifying_marks.join(', ') }}
+      </dd>
+    </dl>
+  {% endif %}
+  {% if affiliations.length %}
+    <dl class="affiliations">
+      <dt>Known affiliations:</dt>
+      <dd>
+          <ul class="list list-bullet">
+            {% for affiliation in affiliations %}
+            <li><a href="/ocg/{{affiliation.index}}">{{affiliation.name}}</a></li>
+            {% endfor %}
+          </ul>
+      </dd>
+    </dl>
+  {% endif %}
 </div>


### PR DESCRIPTION
This PR cuts down on clutter when variables are missing in search results (e.g. known aliases: none), and moves IDs to a secondary location. This makes it easier for the user to scan through the results. It also makes the avatars much larger in narrow screen/browser widths to make it easier to see the pictures on a mobile.