### PR TITLE
improve behaviour of simple search at mobile and tablet size

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -21,6 +21,7 @@ $path: "/public/images/";
 @import 'local/forms/form-group-inline.scss';
 @import 'local/icons.scss';
 @import 'local/search-results.scss';
+@import 'local/header.scss';
 
 
 

--- a/app/assets/sass/local/header.scss
+++ b/app/assets/sass/local/header.scss
@@ -1,0 +1,81 @@
+#proposition-name {
+  display: block;
+}
+#proposition-links {
+  display: inline-block;
+  float: left;
+}
+
+.simple-search-outer {
+  // height: 2em;
+  // position: absolute;
+  // right: $gutter;
+
+  @include media(tablet) {
+    // position: absolute;
+    // right: $gutter;
+    // top: 15px;
+    float: right;
+    display: inline-block;
+  }
+  @include media(mobile) {
+    position: relative;
+    float: none;
+    right: 0;
+    text-align: center;
+    top: 0;
+    width: 100%;
+  }
+  @media (min-width: 960px) {
+    // right: calc((100% - 960px)/2);
+  }
+
+  .form-group {
+    margin: 0;
+  }
+  .form-control {
+    height: 2em;
+    font-size: 90%;
+    width: auto;
+    @include media(mobile) {
+      width: 100%;
+    }
+  }
+  .button-search {
+    margin-top:0.25em;
+    background-color:transparent;
+    background-size:cover;
+    background-repeat:no-repeat;
+    height: 2em;
+    width: 2em;
+
+    @include media(mobile) {
+      background-size: 2em, 2em;
+      background-position: center;
+      border: 1px outset white;
+      margin: 0 0 0 2px;
+      padding: 0;
+      width: calc(100% - 4px);
+    }
+  }
+}
+
+#global-header .header-proposition #proposition-link li,
+#global-header .header-proposition #proposition-links li {
+  @include media(tablet) {
+    display: block;
+    a {
+      display: block;
+    }
+  }
+  @include media(mobile) {
+    display: block;
+    a {
+      display: block;
+    }
+  }
+}
+
+.js-enabled #global-header .header-proposition #proposition-links.js-visible {
+  width: 100%;
+}

--- a/app/assets/sass/local/header.scss
+++ b/app/assets/sass/local/header.scss
@@ -1,20 +1,5 @@
-#proposition-name {
-  display: block;
-}
-#proposition-links {
-  display: inline-block;
-  float: left;
-}
-
 .simple-search-outer {
-  // height: 2em;
-  // position: absolute;
-  // right: $gutter;
-
   @include media(tablet) {
-    // position: absolute;
-    // right: $gutter;
-    // top: 15px;
     float: right;
     display: inline-block;
   }
@@ -25,9 +10,6 @@
     text-align: center;
     top: 0;
     width: 100%;
-  }
-  @media (min-width: 960px) {
-    // right: calc((100% - 960px)/2);
   }
 
   .form-group {
@@ -58,6 +40,14 @@
       width: calc(100% - 4px);
     }
   }
+}
+
+#proposition-name {
+  display: block;
+}
+#proposition-links {
+  display: inline-block;
+  float: left;
 }
 
 #global-header .header-proposition #proposition-link li,

--- a/app/assets/sass/local/header.scss
+++ b/app/assets/sass/local/header.scss
@@ -69,3 +69,11 @@
 .js-enabled #global-header .header-proposition #proposition-links.js-visible {
   width: 100%;
 }
+
+.user-menu {
+  margin-left: 15px;
+
+  li, a {
+    color: $white;
+  }
+}

--- a/app/assets/sass/local/icons.scss
+++ b/app/assets/sass/local/icons.scss
@@ -1,49 +1,5 @@
 .simple-search-outer{
-	height:2em;
-	position:absolute;
-	right: $gutter;
-	@include media(tablet) {
-		position:absolute;
-		right: $gutter;
-		top: 15px;
-	}	
-	@include media(mobile) {
-		position:absolute;
-		right: $gutter-half;
-		top: 15px;
-	}
-	@media (min-width: 960px) {
-		right: calc((100% - 960px)/2);	
-	}	
-
-	.form-group {
-		margin: 2px 0;
-	}
-	.form-control {
-		height: 2em;
-		font-size: 90%;
-		width: auto;
-	}
-	select {
-		/*
-	  -webkit-appearance: none;
-	  -webkit-border-radius: 0px;
-		border-top-right-radius: 0;
-		border-bottom-right-radius: 0;
-		*/
-		/*
-		border: 0;
-    outline: 1px solid #CCC;
-    background-color: white;
-    */
-	}
 	.button-search{
 		@include icon('icon-search', 30 , 22 , false);
-		margin-top:0.25em;
-		background-color:transparent;
-		background-size:cover;
-		background-repeat:no-repeat;
-		height: 2em;
-		width: 2em;
 	}
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -108,7 +108,7 @@ router.get('/nominal/:index', function(req, res) {
 });
 
 router.get('/nominal/', function(req, res) {
-  res.redirect('/nominal/0');
+  res.redirect('/nominal/search/new');
 });
 
 
@@ -133,7 +133,7 @@ router.get('/ocg/:index', function(req, res) {
 });
 
 router.get('/ocg/', function(req, res) {
-  res.redirect('/ocg/0');
+  res.redirect('/ocg/search/new');
 });
 
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -13,11 +13,19 @@
   {% set userType = data['user_type'] %}
 {% endif %}
 
+{% block inside_header %}
+<ul style="color: #fff !important; margin-left: 15px;">
+  <li>{{userType}}@example.com</li>
+  <li><a style="color: #fff !important" href="/signout">Sign out</a></li>
+</ul>
+{% endblock %}
+
 {% block proposition_header %}
 
   <div class="header-proposition">
     <div class="content">
       <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+
       <nav id="proposition-menu">
         <a href="/" id="proposition-name">
           {# Set serviceName in config.js. Use a block to override on a page. #}
@@ -25,32 +33,31 @@
             {% if serviceName %} {{ serviceName }} {% endif %}
           {% endblock %}
         </a>
-
-        {% block user_items %}
-          <ul id="proposition-links">
-            <li>Signed in as {{userType}}@example.com</li>
-            <li><a href="/signout">Sign out</a></li>
-          </ul>
-        {% endblock %}
-
+        <ul id="proposition-links">
+          <li><a href="/nominal">Nominals</a></li>
+          <li><a href="/ocg">OCGs</a></li>
+        </ul>
+        <div class='simple-search-outer'>
+          <form id="simple-search" action="/simple_search_action.html" method="get">
+            <div class="form-group">
+              <fieldset class="inline">
+                <select name="search-scope" class="form-control">
+                {% for scope in ['Nominals', 'OCGs'] %}
+                  <option value='{{ scope | lower }}'>{{ scope }}</option>
+                {% endfor %}
+                </select>
+                <label class="visually-hidden" for="q">Search for</label>
+                <input name="q" id="q" placeholder="search" class="form-control" value="{{data['q']}}" />
+                <input type="submit" class="button-search form-control" value="" />
+              </fieldset>
+            </div>
+          </form>
+        </div>
       </nav>
+
+
     </div>
-  </div>
-  <div class='simple-search-outer'>
-    <form id="simple-search" action="/simple_search_action.html" method="get">
-      <div class="form-group">
-        <fieldset class="inline">
-          <select name="search-scope" class="form-control">
-          {% for scope in ['Nominals', 'OCGs'] %}
-            <option value='{{ scope | lower }}'>{{ scope }}</option>
-          {% endfor %}
-          </select>
-          <label class="visually-hidden" for="q">Search for</label>
-          <input name="q" id="q" placeholder="search" class="form-control" value="{{data['q']}}" />
-          <input type="submit" class="button-search form-control" value="" />
-        </fieldset>
-      </div>
-    </form>
+
   </div>
 
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -14,9 +14,9 @@
 {% endif %}
 
 {% block inside_header %}
-<ul style="color: #fff !important; margin-left: 15px;">
+<ul class="user-menu">
   <li>{{userType}}@example.com</li>
-  <li><a style="color: #fff !important" href="/signout">Sign out</a></li>
+  <li><a href="/signout">Sign out</a></li>
 </ul>
 {% endblock %}
 

--- a/app/views/nominal/search/results.html
+++ b/app/views/nominal/search/results.html
@@ -10,13 +10,9 @@
   {% include 'includes/phase_banner_prototype.html' %}
 
   <div class="grid-row">
-    <div class="column-two-thirds">
-
-      <h1 class="heading-xlarge">
-        Nominal Search Results
-      </h1>
-
-    </div>
+    <h1 class="heading-xlarge">
+      Nominal Search Results
+    </h1>
   </div>
 
   <div class="grid-row">

--- a/app/views/ocg/search/results.html
+++ b/app/views/ocg/search/results.html
@@ -10,13 +10,9 @@
   {% include 'includes/phase_banner_prototype.html' %}
 
   <div class="grid-row">
-    <div class="column-two-thirds">
-
-      <h1 class="heading-xlarge">
-        Organised Crime Group Search Results
-      </h1>
-
-    </div>
+    <h1 class="heading-xlarge">
+      Organised Crime Group Search Results
+    </h1>
   </div>
 
   <div class="grid-row">


### PR DESCRIPTION
* Simple search now sticks to the top right at tablet and wider, and wraps to full-width fields at mobile.
* The proposition nav elements now have full-width click targets at mobile & tablet size

<img width="409" alt="screen shot 2017-06-28 at 14 53 15" src="https://user-images.githubusercontent.com/134501/27640566-9279062e-5c11-11e7-8735-41cf196b8520.png">
