### PR TITLE
simplify and de-clutter the header, and make it work better on small screens

### DIFF
--- a/app/assets/sass/local/header.scss
+++ b/app/assets/sass/local/header.scss
@@ -24,12 +24,16 @@
     }
   }
   .button-search {
-    margin-top:0.25em;
     background-color:transparent;
-    background-size:cover;
-    background-repeat:no-repeat;
-    height: 2em;
-    width: 2em;
+    background-size: 1.8em;
+    background-position: 0.1em 0.2em;
+    background-repeat: no-repeat;
+    border: 1px outset white;
+    border-left: none;
+    height: 1.75em;
+    margin-left: 0;
+    margin-top: 2px;
+    width: 1.8em;
 
     @include media(mobile) {
       background-size: 2em, 2em;
@@ -49,7 +53,12 @@
   display: inline-block;
   float: left;
 }
-
+#global-header.with-proposition .header-wrapper .header-proposition {
+  width: auto;
+}
+#global-header.with-proposition .header-wrapper .header-global {
+  width: auto;
+}
 #global-header .header-proposition #proposition-link li,
 #global-header .header-proposition #proposition-links li {
   @include media(tablet) {
@@ -70,10 +79,15 @@
   width: 100%;
 }
 
+#user-and-search {
+  
+}
 .user-menu {
-  margin-left: 15px;
+  float: left;
 
   li, a {
     color: $white;
+    display: inline-block;
+    list-style-type: none;
   }
 }

--- a/app/assets/sass/local/header.scss
+++ b/app/assets/sass/local/header.scss
@@ -1,14 +1,11 @@
 .simple-search-outer {
   @include media(tablet) {
     float: right;
-    display: inline-block;
+    clear: both;
   }
   @include media(mobile) {
-    position: relative;
     float: none;
-    right: 0;
     text-align: center;
-    top: 0;
     width: 100%;
   }
 
@@ -50,40 +47,82 @@
   display: block;
 }
 #proposition-links {
+  clear: left;
   display: inline-block;
   float: left;
+  margin-left: 5px;
+
+  li {
+    float: left;
+    a {
+      font-weight: 700;
+      padding: 2px 10px;
+      text-decoration: none;
+      width: 7em;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @include media(mobile) {
+    display: block;
+    float: none;
+    overflow: hidden;
+    width: 100%;
+
+    li {
+      display: inline-block;
+      width: 49%;
+
+      a {
+        display: block;
+      }
+    }
+  }
 }
-#global-header.with-proposition .header-wrapper .header-proposition {
-  width: auto;
+.js-enabled #proposition-links.js-visible {
+  width: 100%;
+}
+
+#global-header.with-proposition .header-wrapper {
+  padding: 10px 20px;
 }
 #global-header.with-proposition .header-wrapper .header-global {
   width: auto;
 }
-#global-header .header-proposition #proposition-link li,
-#global-header .header-proposition #proposition-links li {
-  @include media(tablet) {
-    display: block;
-    a {
-      display: block;
-    }
-  }
+#global-header.with-proposition .header-wrapper .header-proposition  {
+  padding-top: 6px;
+  width: 80%;
+  
   @include media(mobile) {
-    display: block;
-    a {
-      display: block;
-    }
+    width: 100%;
   }
-}
 
-.js-enabled #global-header .header-proposition #proposition-links.js-visible {
-  width: 100%;
+
 }
 
 #user-and-search {
-  
+  float: right;
+  margin-right: 15px;
+  overflow: hidden;
+  width: auto;
+
+  @include media(mobile) {
+    float: none;
+    width: 100%;
+  }
+  input {
+    padding: 9px;
+  }
 }
-.user-menu {
+#name-and-menu {
   float: left;
+}
+
+
+.user-menu {
+  float: right;
 
   li, a {
     color: $white;

--- a/app/assets/sass/local/icons.scss
+++ b/app/assets/sass/local/icons.scss
@@ -1,5 +1,6 @@
 .simple-search-outer{
 	.button-search{
 		@include icon('icon-search', 30 , 22 , false);
+    cursor: pointer;
 	}
 }

--- a/app/views/includes/simple_search_form.html
+++ b/app/views/includes/simple_search_form.html
@@ -1,0 +1,15 @@
+
+<form id="simple-search" action="/simple_search_action.html" method="get">
+  <div class="form-group">
+    <fieldset class="inline">
+      <select name="search-scope" class="form-control">
+      {% for scope in ['Nominals', 'OCGs'] %}
+        <option value='{{ scope | lower }}'>{{ scope }}</option>
+      {% endfor %}
+      </select>
+      <label class="visually-hidden" for="q">Search for</label>
+      <input name="q" id="q" placeholder="search" class="form-control" value="{{data['q']}}" />
+      <input type="submit" class="button-search form-control" value="" />
+    </fieldset>
+  </div>
+</form>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -13,58 +13,27 @@
   {% set userType = data['user_type'] %}
 {% endif %}
 
+{% set homepage_url = "/" %}
+{% set global_header_text=serviceName %}
 {% block inside_header %}
 
 {% endblock %}
 
 {% block proposition_header %}
-
-  <div class="header-proposition">
-    <div class="content">
-      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
-
-      <nav id="proposition-menu">
-        <div id="name-and-menu">
-          <a href="/" id="proposition-name">
-            {# Set serviceName in config.js. Use a block to override on a page. #}
-            {% block service_name %}
-              {% if serviceName %} {{ serviceName }} {% endif %}
-            {% endblock %}
-          </a>
-          <ul id="proposition-links">
-            <li><a href="/nominal">Nominals</a></li>
-            <li><a href="/ocg">OCGs</a></li>
-          </ul>
-        </div>
-        <div id="user-and-search">
-          <ul class="user-menu">
-            <li>{{userType}}@example.com</li>
-            <li><a href="/signout">Sign out</a></li>
-          </ul>
-          <div class='simple-search-outer'>
-            <form id="simple-search" action="/simple_search_action.html" method="get">
-              <div class="form-group">
-                <fieldset class="inline">
-                  <select name="search-scope" class="form-control">
-                  {% for scope in ['Nominals', 'OCGs'] %}
-                    <option value='{{ scope | lower }}'>{{ scope }}</option>
-                  {% endfor %}
-                  </select>
-                  <label class="visually-hidden" for="q">Search for</label>
-                  <input name="q" id="q" placeholder="search" class="form-control" value="{{data['q']}}" />
-                  <input type="submit" class="button-search form-control" value="" />
-                </fieldset>
-              </div>
-            </form>
-          </div>
-        </div>
-      </nav>
-
-
+  <div id="user-and-search">
+    <ul class="user-menu">
+      <li>{{userType}}@example.com</li>
+      <li><a href="/signout">Sign out</a></li>
+    </ul>
+    <div class='simple-search-outer'>
+      {% include 'includes/simple_search_form.html' %}
     </div>
-
   </div>
 
+  <ul id="proposition-links">
+    <li><a href="/nominal">Nominals</a></li>
+    <li><a href="/ocg">OCGs</a></li>
+  </ul>
 {% endblock %}
 
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -14,10 +14,7 @@
 {% endif %}
 
 {% block inside_header %}
-<ul class="user-menu">
-  <li>{{userType}}@example.com</li>
-  <li><a href="/signout">Sign out</a></li>
-</ul>
+
 {% endblock %}
 
 {% block proposition_header %}
@@ -27,31 +24,39 @@
       <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
 
       <nav id="proposition-menu">
-        <a href="/" id="proposition-name">
-          {# Set serviceName in config.js. Use a block to override on a page. #}
-          {% block service_name %}
-            {% if serviceName %} {{ serviceName }} {% endif %}
-          {% endblock %}
-        </a>
-        <ul id="proposition-links">
-          <li><a href="/nominal">Nominals</a></li>
-          <li><a href="/ocg">OCGs</a></li>
-        </ul>
-        <div class='simple-search-outer'>
-          <form id="simple-search" action="/simple_search_action.html" method="get">
-            <div class="form-group">
-              <fieldset class="inline">
-                <select name="search-scope" class="form-control">
-                {% for scope in ['Nominals', 'OCGs'] %}
-                  <option value='{{ scope | lower }}'>{{ scope }}</option>
-                {% endfor %}
-                </select>
-                <label class="visually-hidden" for="q">Search for</label>
-                <input name="q" id="q" placeholder="search" class="form-control" value="{{data['q']}}" />
-                <input type="submit" class="button-search form-control" value="" />
-              </fieldset>
-            </div>
-          </form>
+        <div id="name-and-menu">
+          <a href="/" id="proposition-name">
+            {# Set serviceName in config.js. Use a block to override on a page. #}
+            {% block service_name %}
+              {% if serviceName %} {{ serviceName }} {% endif %}
+            {% endblock %}
+          </a>
+          <ul id="proposition-links">
+            <li><a href="/nominal">Nominals</a></li>
+            <li><a href="/ocg">OCGs</a></li>
+          </ul>
+        </div>
+        <div id="user-and-search">
+          <ul class="user-menu">
+            <li>{{userType}}@example.com</li>
+            <li><a href="/signout">Sign out</a></li>
+          </ul>
+          <div class='simple-search-outer'>
+            <form id="simple-search" action="/simple_search_action.html" method="get">
+              <div class="form-group">
+                <fieldset class="inline">
+                  <select name="search-scope" class="form-control">
+                  {% for scope in ['Nominals', 'OCGs'] %}
+                    <option value='{{ scope | lower }}'>{{ scope }}</option>
+                  {% endfor %}
+                  </select>
+                  <label class="visually-hidden" for="q">Search for</label>
+                  <input name="q" id="q" placeholder="search" class="form-control" value="{{data['q']}}" />
+                  <input type="submit" class="button-search form-control" value="" />
+                </fieldset>
+              </div>
+            </form>
+          </div>
         </div>
       </nav>
 


### PR DESCRIPTION
Tablet size (640 - 768px wide) could still do with a bit of tidying up, but this seems to work far better as you resize the window, and also removes a lot of cruft in the markup that just got in the way.

Well aware that this is a bit of a stylistic change also, so if you just don't like how it looks, feel free to not approve it, but the flakey wrapping behaviour was irritating me so much I had to do something :)

### Full-width
<img width="1016" alt="screen shot 2017-06-29 at 11 17 55" src="https://user-images.githubusercontent.com/134501/27683260-3a8fa844-5cbd-11e7-819a-4ce623457cf7.png">

### Mobile
<img width="468" alt="screen shot 2017-06-29 at 11 18 18" src="https://user-images.githubusercontent.com/134501/27683261-3a908b74-5cbd-11e7-9e3c-b06eab311f99.png">

### Tablet
<img width="590" alt="screen shot 2017-06-29 at 11 18 32" src="https://user-images.githubusercontent.com/134501/27683262-3a92cb0a-5cbd-11e7-8a21-61c4a73805f6.png">
